### PR TITLE
Simplify ffsend command, add Dutch translation, improve README style

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,19 @@ How to Install / Nasıl Kurulur
 1. Download ffsend binary from following link.
 
    Aşağıdaki bağlantıdan ffsend ikili dosyasını indirin.
-   
+
    https://github.com/timvisee/ffsend/releases
-   
+
 2. Copy ffsend file to /opt dir and rename to ffsend.
 
    ffsend dosyasını /opt dizinine kopyalayın ve adını ffsend olarak değiştirin.
-   
+
 3. Install nemo-ffsend action with following commands.
 
    nemo-ffsend aksiyonunu aşağıdaki komutlarla kurun.
-   
-`wget https://raw.githubusercontent.com/kelebek333/nemo-ffsend/master/usr/share/nemo/actions/ffsend.nemo_action`
 
-`sudo mv ./ffsend.nemo_action /usr/share/nemo/actions`
+  ```bash
+  wget https://raw.githubusercontent.com/kelebek333/nemo-ffsend/master/usr/share/nemo/actions/ffsend.nemo_action`
+
+  sudo mv ./ffsend.nemo_action /usr/share/nemo/actions
+  ```

--- a/usr/share/nemo/actions/ffsend.nemo_action
+++ b/usr/share/nemo/actions/ffsend.nemo_action
@@ -1,9 +1,10 @@
 [Nemo Action]
 
 Name=Upload to Firefox Send
+Name[nl]=Uploaden naar Firefox Send
 Name[tr]=Firefox Send'e Yükle
 Icon-Name=firefox-symbolic
-Exec=/bin/sh -c "/opt/ffsend upload --password --archive '%F' | grep Share | firefox --new-window $(awk '{print $3}');bash"
+Exec=/bin/sh -c "/opt/ffsend upload --quiet --password --archive '%F' | firefox --new-window $(xargs); bash"
 Selection=any
 Extensions=any;
 Terminal=true


### PR DESCRIPTION
Awesome, liking this! `ffsend` developer here :smile: 

I noticed you are using `printf` to grab the URL from `ffsend` output. When using the `--quiet` parameter, the binary only outputs the share URL making things simpler and more reliable. Please give it a try yourself before accepting, I was not able to test it as I'm not using nemo right now.

I also added a Dutch translation, and improved the README formatting slightly.